### PR TITLE
Update SimpleTranslator.php (file was outdated)

### DIFF
--- a/src/Overrides/Lang/SimpleTranslator.php
+++ b/src/Overrides/Lang/SimpleTranslator.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Str;
  */
 class SimpleTranslator extends Translator
 {
-    public function get($key, array $replace = array(), $locale = null)
+    public function get($key, array $replace = array(), $locale = null, $fallback = true)
     {
         if (Str::contains($key, '.')) {
             return parent::get($key, $replace, $locale);

--- a/src/Overrides/Lang/SimpleTranslator.php
+++ b/src/Overrides/Lang/SimpleTranslator.php
@@ -14,11 +14,11 @@ class SimpleTranslator extends Translator
     public function get($key, array $replace = array(), $locale = null, $fallback = true)
     {
         if (Str::contains($key, '.')) {
-            return parent::get($key, $replace, $locale);
+            return parent::get($key, $replace, $locale, $fallback);
         }
 
         $defaultPrefix = config('translation.default_prefix');
 
-        return parent::get("$defaultPrefix.$key", $replace, $locale);
+        return parent::get("$defaultPrefix.$key", $replace, $locale, $fallback);
     }
 }


### PR DESCRIPTION
--added new parameter `$fallback = true`

Laravel may have updated Translator.php
https://github.com/laravel/framework/blob/5.1/src/Illuminate/Translation/Translator.php#L88

since SimpleTranslator.php extends Translator.php the parameters isn't the same, thus i added the `$fallback = true`
